### PR TITLE
simplify ipc code

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,6 @@
         "electron-vite": "^2.3.0",
         "eslint": "^8.57.0",
         "eslint-plugin-react": "^7.34.3",
-        "prettier": "^3.3.2",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "vite": "^5.3.1"
@@ -6245,6 +6244,7 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.4.2.tgz",
       "integrity": "sha512-e9MewbtFo+Fevyuxn/4rrcDAaq0IYxPGLvObpQjiZBMAzB9IGmzlnG9RZy3FFas+eBMu2vA0CszMeduow5dIuQ==",
       "dev": true,
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },

--- a/src/preload/index.js
+++ b/src/preload/index.js
@@ -1,18 +1,3 @@
-import { contextBridge, ipcRenderer } from 'electron'
-import { electronAPI } from '@electron-toolkit/preload'
+import { exposeElectronAPI } from '@electron-toolkit/preload'
 
-const api = {
-  foo: (data) => ipcRenderer.invoke('sendSignal', data)
-}
-
-if (process.contextIsolated) {
-  try {
-    contextBridge.exposeInMainWorld('electron', electronAPI)
-    contextBridge.exposeInMainWorld('api', api)
-  } catch (error) {
-    console.error(error)
-  }
-} else {
-  window.electron = electronAPI
-  window.api = api
-}
+exposeElectronAPI()

--- a/src/renderer/src/App.jsx
+++ b/src/renderer/src/App.jsx
@@ -1,9 +1,11 @@
 import { useEffect } from 'react'
 import electronLogo from './assets/electron.svg'
 
+const ipcr = window.electron.ipcRenderer
+
 function App() {
   useEffect(() => {
-    (async (data="test") => await window.api.foo(data))()
+    (async (data="test") => await ipcr.invoke('sendSignal', data))()
   }, [])
 
 


### PR DESCRIPTION
Пакет '@electron-toolkit/preload' создан чтобы пробросить `IpcRenderer` и прочие api в renderer и не писать в preload этот код:
```
const api = {
  getPartners: () => ipcRenderer.invoke('getPartners'),
  createPartner: (partner) => ipcRenderer.invoke('createPartner', partner),
  updatePartner: (partner) => ipcRenderer.invoke('updatePartner', partner)
}
```
Я выбрал самый простой способ без `contextBridge.exposeInMainWorld`. В renderer можно сразу вызывать `invoke`. Константу `ipcr` можно и не определять, у нас там один вызов на файл, но для примера я выделил. Можно `backend` назвать. Проверил это на electron-demo-latest. Про preload можно забыть. Не то чтобы сильно очень сокращает код, но попроще. Там можно ошибку сделать. Ну мне кажется проще. Можно не принимать, это для наглядности разницы. Как студентов оповещать, ну можно через кураторов сообщить чтобы проверяли обновления шаблона.